### PR TITLE
Use DOCKER_PAT for release.yml GHCR auth

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,7 @@ jobs:
   release-operator:
     name: Release Operator Image
     runs-on: ubuntu-latest
+    environment: DockerBuild
     permissions:
       contents: read
       packages: write
@@ -32,7 +33,7 @@ jobs:
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          password: ${{ secrets.DOCKER_PAT }}
 
       - name: Extract metadata
         id: meta
@@ -58,6 +59,7 @@ jobs:
   release-echo-server:
     name: Release Echo Server Image
     runs-on: ubuntu-latest
+    environment: DockerBuild
     permissions:
       contents: read
       packages: write
@@ -76,7 +78,7 @@ jobs:
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          password: ${{ secrets.DOCKER_PAT }}
 
       - name: Extract metadata
         id: meta


### PR DESCRIPTION
## Summary
- Switches `release.yml` operator + echo-server jobs from `GITHUB_TOKEN` to `DOCKER_PAT` via the `DockerBuild` environment

## Why
`GITHUB_TOKEN` authenticates to GHCR successfully (login works) but cannot push to user-namespace packages (`ghcr.io/atippey/*`) — push fails with `permission_denied: write_package`. This is the same issue we hit and resolved in `ci.yml`.

The PAT is unchanged; it was already in the `DockerBuild` environment and working for `ci.yml`. Just wiring it up for `release.yml` too.

## Test plan
- [ ] Merge this
- [ ] Tag a new version (`v0.0.10` or similar) — release.yml should now succeed in pushing multi-arch images
- [ ] Verify with `crane ls ghcr.io/atippey/mcp-operator` that the new tag appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)